### PR TITLE
fix: add pluggable job execution bootstrap callback for timer jobs #8762

### DIFF
--- a/src/Impl/JobExecutor/ExecuteJobsRunnable.php
+++ b/src/Impl/JobExecutor/ExecuteJobsRunnable.php
@@ -33,11 +33,14 @@ class ExecuteJobsRunnable implements RunnableInterface
     protected static $loadedProcessEngineConfiguration;
     protected static $loadedProcessEngine;
     protected bool $queued = false;
+    protected $jobExecutionBootstrap;
+    protected bool $jobExecutionBootstrapInvoked = false;
 
-    public function __construct(array $jobIds, ProcessEngineImpl $processEngine)
+    public function __construct(array $jobIds, ProcessEngineImpl $processEngine, ?callable $jobExecutionBootstrap = null)
     {
         $this->jobIds = $jobIds;
         $this->processEngine = $processEngine;
+        $this->jobExecutionBootstrap = $jobExecutionBootstrap;
         //$this->jobExecutor = $processEngine->getProcessEngineConfiguration()->getJobExecutor();
     }
 
@@ -45,7 +48,10 @@ class ExecuteJobsRunnable implements RunnableInterface
     {
         return [
             'jobIds' => $this->jobIds,
-            'resource' => $this->processEngine->getProcessEngineConfiguration()->getResource()
+            'resource' => $this->processEngine->getProcessEngineConfiguration()->getResource(),
+            'jobExecutionBootstrap' => $this->isSerializableBootstrap($this->jobExecutionBootstrap)
+                ? $this->jobExecutionBootstrap
+                : null
         ];
     }
 
@@ -54,11 +60,14 @@ class ExecuteJobsRunnable implements RunnableInterface
         $this->queued = true;
         $this->jobIds = $data['jobIds'];
         $this->resource = $data['resource'];
+        $this->jobExecutionBootstrap = $data['jobExecutionBootstrap'] ?? null;
     }
 
     public function run(ThreadInterface $process = null, ...$args): void
     {
         $this->ensureProcessEngineConfigurationExists(...$args);
+
+        $this->invokeJobExecutionBootstrap();
 
         $jobExecutorContext = new JobExecutorContext();
         $currentProcessorJobQueue = $jobExecutorContext->getCurrentProcessorJobQueue();
@@ -112,6 +121,48 @@ class ExecuteJobsRunnable implements RunnableInterface
         if ($this->processEngine === null && self::$loadedProcessEngine !== null) {
             $this->processEngine = self::$loadedProcessEngine;
         }
+    }
+
+    private function invokeJobExecutionBootstrap(): void
+    {
+        if ($this->jobExecutionBootstrapInvoked) {
+            return;
+        }
+
+        try {
+            if (is_callable($this->jobExecutionBootstrap)) {
+                $this->callBootstrap($this->jobExecutionBootstrap);
+            }
+        } catch (\Throwable $e) {
+            fwrite(STDERR, sprintf("[%s] Job execution bootstrap failed: %s\n", date("d-m-Y H:i:s"), $e->getMessage()));
+        }
+
+        $this->jobExecutionBootstrapInvoked = true;
+    }
+
+    private function callBootstrap(callable $bootstrap): void
+    {
+        if (is_array($bootstrap) && count($bootstrap) === 2) {
+            $reflection = new \ReflectionMethod($bootstrap[0], $bootstrap[1]);
+        } else {
+            $reflection = new \ReflectionFunction(\Closure::fromCallable($bootstrap));
+        }
+
+        if ($reflection->getNumberOfParameters() > 0) {
+            $bootstrap($this->processEngine);
+            return;
+        }
+
+        $bootstrap();
+    }
+
+    private function isSerializableBootstrap($bootstrap): bool
+    {
+        if (!is_callable($bootstrap)) {
+            return false;
+        }
+
+        return !($bootstrap instanceof \Closure);
     }
 
     protected function executeJob(?string $nextJobId, CommandExecutorInterface $commandExecutor, JobFailureCollector $jobFailureCollector, ...$args): void

--- a/src/Impl/JobExecutor/JobExecutor.php
+++ b/src/Impl/JobExecutor/JobExecutor.php
@@ -49,6 +49,11 @@ abstract class JobExecutor
     protected $lockOwner;
     protected int $lockTimeInMillis = 5 * 30 * 1000;
 
+    /**
+     * @var callable|null
+     */
+    protected $jobExecutionBootstrap = null;
+
     protected $state = [];
 
     public function __construct(...$args)
@@ -152,8 +157,8 @@ abstract class JobExecutor
     {
         if ($engine->getProcessEngineConfiguration()->isMetricsEnabled()) {
             $engine->getProcessEngineConfiguration()
-            ->getMetricsRegistry()
-            ->markOccurrence(Metrics::JOB_ACQUISITION_ATTEMPT);
+                ->getMetricsRegistry()
+                ->markOccurrence(Metrics::JOB_ACQUISITION_ATTEMPT);
         }
     }
 
@@ -161,8 +166,8 @@ abstract class JobExecutor
     {
         if ($engine !== null && $engine->getProcessEngineConfiguration()->isMetricsEnabled()) {
             $engine->getProcessEngineConfiguration()
-            ->getMetricsRegistry()
-            ->markOccurrence(Metrics::JOB_ACQUIRED_SUCCESS, $numJobs);
+                ->getMetricsRegistry()
+                ->markOccurrence(Metrics::JOB_ACQUIRED_SUCCESS, $numJobs);
         }
     }
 
@@ -170,8 +175,8 @@ abstract class JobExecutor
     {
         if ($engine !== null && $engine->getProcessEngineConfiguration()->isMetricsEnabled()) {
             $engine->getProcessEngineConfiguration()
-            ->getMetricsRegistry()
-            ->markOccurrence(Metrics::JOB_ACQUIRED_FAILURE, $numJobs);
+                ->getMetricsRegistry()
+                ->markOccurrence(Metrics::JOB_ACQUIRED_FAILURE, $numJobs);
         }
     }
 
@@ -179,8 +184,8 @@ abstract class JobExecutor
     {
         if ($engine !== null && $engine->getProcessEngineConfiguration()->isMetricsEnabled()) {
             $engine->getProcessEngineConfiguration()
-            ->getMetricsRegistry()
-            ->markOccurrence(Metrics::JOB_EXECUTION_REJECTED, $numJobs);
+                ->getMetricsRegistry()
+                ->markOccurrence(Metrics::JOB_EXECUTION_REJECTED, $numJobs);
         }
     }
 
@@ -392,6 +397,16 @@ abstract class JobExecutor
 
     public function getExecuteJobsRunnable(array $jobIds, ProcessEngineImpl $processEngine): RunnableInterface
     {
-        return new ExecuteJobsRunnable($jobIds, $processEngine);
+        return new ExecuteJobsRunnable($jobIds, $processEngine, $this->jobExecutionBootstrap);
+    }
+
+    public function setJobExecutionBootstrap(?callable $jobExecutionBootstrap): void
+    {
+        $this->jobExecutionBootstrap = $jobExecutionBootstrap;
+    }
+
+    public function getJobExecutionBootstrap(): ?callable
+    {
+        return $this->jobExecutionBootstrap;
     }
 }


### PR DESCRIPTION
Задача
 #8762: восстановить выполнение timer jobs без прямой зависимости jabe от BpmnEngine.

Что сделано:
1) В JobExecutor добавлен нейтральный callback-хук bootstrap:
- setJobExecutionBootstrap()
- getJobExecutionBootstrap()
2) В getExecuteJobsRunnable() callback передается в ExecuteJobsRunnable.
3) В ExecuteJobsRunnable::run() добавлен вызов bootstrap перед исполнением jobs.
4) Добавлен безопасный вызов callback с обработкой ошибок:
- invokeJobExecutionBootstrap()
- callBootstrap()