### PR TITLE
fix: double type for DoubleType serializer matching #9081

### DIFF
--- a/src/Variable/Impl/Type/DoubleTypeImpl.php
+++ b/src/Variable/Impl/Type/DoubleTypeImpl.php
@@ -14,7 +14,7 @@ class DoubleTypeImpl extends PrimitiveValueTypeImpl
 {
     public function __construct()
     {
-        parent::__construct(null, "float");
+        parent::__construct(null, "double");
     }
 
     public function createValue($value, ?array $valueInfo = null): DoubleValueInterface


### PR DESCRIPTION
Что исправлено: 

- в src/Variable/Impl/Type/DoubleTypeImpl.php ожидаемый PHP-тип изменен `float` -> `double`

Причины: 

- В PHP `gettype()` для дробных чисел возвращает `double`
- Из-за `float` сериализатор не  подбирался для значений геометрии (координат), что приводило к ошибке `Cannot find serializer for value 'Untyped value ...'`